### PR TITLE
disable submitting form with closed status but no closed_on date

### DIFF
--- a/app/views/service_requests/_form.html.erb
+++ b/app/views/service_requests/_form.html.erb
@@ -162,7 +162,8 @@
       <div class="col-sm-10">
         <%= f.text_field :closed_on, class: 'form-control',
           'placeholder' => 'YYYY-MM-DD',
-          'ng-model' => 'request.closed_on' %>
+          'ng-model' => 'request.closed_on',
+          'ng-required' => "request.status == 'closed'" %>
       </div>
     </div>
 


### PR DESCRIPTION
This PR hides the closed_at date unless status is changed to closed, and requires the closed_at date once that is the status (but doesn't require it when hidden)

@nevern02 This could be merged as is, it works, but I think I'm missing something on how to do the form validation correctly, I have a hack comment on the thing I dislike and a couple commented outlines nearby that I tried and didn't work.
